### PR TITLE
Added convolution test for lensed galaxy

### DIFF
--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -91,8 +91,41 @@ def test_truncate():
     np.testing.assert_array_almost_equal(image_conv2, image_conv, decimal=5)
     return
 
+def test_convolved_lensed(gamma1=0.2, gamma2=0.0, kappa=0.0):
+    # reduced shear and lensing magnification
+    g1 = gamma1 / (1 - kappa)
+    g2 = gamma2 / (1 - kappa)
+    mu = 1 / ((1 - kappa) ** 2 - gamma1**2 - gamma2**2)
+
+    lensed_gal = gal.lens(g1=g1, g2=g2, mu=mu)
+    conv_gal = galsim.Convolve([lensed_gal, psf])
+    # # apply lensing shear to galaxy
+    lens = batsim.LensTransform(gamma1=gamma1, gamma2=gamma2, kappa=kappa)
+
+    # get galaxy array from stamp object
+    gal_array = batsim.simulate_galaxy(
+        ngrid=nn,
+        pix_scale=scale,
+        gal_obj=gal,
+        transform_obj=lens,
+        psf_obj=psf
+    )
+
+    # apply the distortion with Galsim note that we need to use lens instead of
+    # shear which is the nature lensing shear that conserve surface density.
+    # the galsim.shear function is flux conservative (Based on the report from
+    # Gary Yang)
+    gal_galsim = (
+        conv_gal.shift(0.5 * scale, 0.5 * scale).drawImage(
+            nx=nn, ny=nn, scale=scale, method="no_pixel"
+        )
+    ).array
+    np.testing.assert_array_almost_equal(gal_array, gal_galsim)
+    return
+
 
 if __name__ == "__main__":
     test_base()
     test_downsample()
     test_truncate()
+    test_convolved_lensed()


### PR DESCRIPTION
Added convolution test for lensed galaxy using batsim.sim.simulate_galaxy()

It appears the psf normalization in this function may be off, as test_affine_shear passes with no psf.
